### PR TITLE
webui direct-to-worker functionality restored

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,9 @@
        <button type="button" data-type="server_cmd" data-string='{"server_cmd": "start"}'>start</button>
        <button type="button" data-type="server_cmd" data-string='{"server_cmd": "stop"}'>stop</button>
        <button type="button" data-type="server_cmd" data-string='{"server_cmd": "kill"}'>kill</button>
+       <br><br>
+       <button type="button" data-type="server_cmd" data-string='{"alt_cmd": "create"}'>create server</button>
+       <button type="button" data-type="server_cmd" data-string='{"alt_cmd": "delete"}'>delete server</button>
        <hr>
      </form>
      <div id="msgs"></div>


### PR DESCRIPTION
recent changes to permissions requires the full hierarchy to be
traversed from the root to the pool to the server.

In the event a mrmanger is not employed, this meant that the pool
ability offered through mrmanager was incomplete and servers
could not be made directly.

this additional route is a bit hacky, but for the time being
is cleanly implemented even if it makes the code a bit more
magical.