### PR TITLE
direct-worker server creation fixed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,8 +45,8 @@
        <button type="button" data-type="server_cmd" data-string='{"server_cmd": "stop"}'>stop</button>
        <button type="button" data-type="server_cmd" data-string='{"server_cmd": "kill"}'>kill</button>
        <br><br>
-       <button type="button" data-type="server_cmd" data-string='{"alt_cmd": "create"}'>create server</button>
-       <button type="button" data-type="server_cmd" data-string='{"alt_cmd": "delete"}'>delete server</button>
+       <button type="button" data-type="server_cmd" data-string='{"server_cmd": "create", "alt_cmd": "create"}'>create server</button>
+       <button type="button" data-type="server_cmd" data-string='{"server_cmd": "delete", "alt_cmd": "delete"}'>delete server</button>
        <hr>
      </form>
      <div id="msgs"></div>


### PR DESCRIPTION
permissions are created server-specific, but reaching out to the
workerpool mrmanager is no longer neccesary so long as the server
name does not match a pool server name.

this means that these servers can still actually be deleted
and created freely since it's basically an unsecured worker.